### PR TITLE
Support AoT on Client Side

### DIFF
--- a/packages/universal-cli/blueprints/ng2/files/__path__/app/app.module.ts
+++ b/packages/universal-cli/blueprints/ng2/files/__path__/app/app.module.ts
@@ -1,6 +1,6 @@
 <% if(!universal) { %>
 import { BrowserModule } from '@angular/platform-browser';<% } else { %>
-import { CommonModule } from '@angular/common'; <% } %>
+import { CommonModule } from '@angular/common';<% } %>
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';<% if (routing) { %>
@@ -14,7 +14,7 @@ import { AppComponent } from './app.component';
   ],
   imports: [<% if(!universal) { %>
     BrowserModule,<% } else { %>
-    CommonModule, <% } %>
+    CommonModule,<% } %>
     FormsModule,
     HttpModule<% if (routing) { %>,
     AppRoutingModule<% } %>

--- a/packages/universal-cli/blueprints/ng2/files/__path__/app/app.module.ts
+++ b/packages/universal-cli/blueprints/ng2/files/__path__/app/app.module.ts
@@ -17,7 +17,7 @@ import { AppComponent } from './app.component';
     HttpModule<% if (routing) { %>,
     AppRoutingModule<% } %>
   ],
-  providers: [],<% if(!universal) { %>
+  providers: [],<% if(universal) { %>
   exports: [AppComponent]<% } else { %>
   bootstrap: [AppComponent]<% } %>
 })

--- a/packages/universal-cli/blueprints/ng2/files/__path__/app/app.module.ts
+++ b/packages/universal-cli/blueprints/ng2/files/__path__/app/app.module.ts
@@ -1,4 +1,5 @@
-import { BrowserModule } from '@angular/platform-browser';
+<% if(!universal) { %>
+import { BrowserModule } from '@angular/platform-browser';<% } %>
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';<% if (routing) { %>
@@ -10,13 +11,14 @@ import { AppComponent } from './app.component';
   declarations: [
     AppComponent
   ],
-  imports: [
-    BrowserModule,
+  imports: [<% if(!universal) { %>
+    BrowserModule,<% } %>
     FormsModule,
     HttpModule<% if (routing) { %>,
     AppRoutingModule<% } %>
   ],
-  providers: [],
-  bootstrap: [AppComponent]
+  providers: [],<% if(!universal) { %>
+  exports: [AppComponent]<% } else { %>
+  bootstrap: [AppComponent]<% } %>
 })
 export class AppModule { }

--- a/packages/universal-cli/blueprints/ng2/files/__path__/app/app.module.ts
+++ b/packages/universal-cli/blueprints/ng2/files/__path__/app/app.module.ts
@@ -1,5 +1,6 @@
 <% if(!universal) { %>
-import { BrowserModule } from '@angular/platform-browser';<% } %>
+import { BrowserModule } from '@angular/platform-browser';<% }  else { %>
+import { CommonModule } from '@angular/common'; <% } %>
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';<% if (routing) { %>
@@ -12,7 +13,8 @@ import { AppComponent } from './app.component';
     AppComponent
   ],
   imports: [<% if(!universal) { %>
-    BrowserModule,<% } %>
+    BrowserModule,<% } else { %>
+    CommonModule, <% } %>
     FormsModule,
     HttpModule<% if (routing) { %>,
     AppRoutingModule<% } %>

--- a/packages/universal-cli/blueprints/ng2/files/__path__/app/app.module.ts
+++ b/packages/universal-cli/blueprints/ng2/files/__path__/app/app.module.ts
@@ -1,5 +1,5 @@
 <% if(!universal) { %>
-import { BrowserModule } from '@angular/platform-browser';<% }  else { %>
+import { BrowserModule } from '@angular/platform-browser';<% } else { %>
 import { CommonModule } from '@angular/common'; <% } %>
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';

--- a/packages/universal-cli/blueprints/ng2/index.js
+++ b/packages/universal-cli/blueprints/ng2/index.js
@@ -85,7 +85,6 @@ module.exports = {
 
     if (this.options && this.options.universal) {
       fileList = fileList.filter(p => p.indexOf('main.ts') < 0);
-      fileList = fileList.filter(p => p.indexOf('app.module.ts') < 0);
     }
 
     return fileList;

--- a/packages/universal-cli/blueprints/universal/files/__path__/app/app.browser.module.ts
+++ b/packages/universal-cli/blueprints/universal/files/__path__/app/app.browser.module.ts
@@ -9,6 +9,7 @@
 import { NgModule } from '@angular/core';
 import { UniversalModule } from 'angular2-universal';
 import { FormsModule } from '@angular/forms';
+import { AppModule } from './app.module';
 import { AppComponent } from './index';
 // import { RouterModule } from '@angular/router';
 // import { appRoutes } from './app/app.routing';
@@ -19,21 +20,19 @@ import { AppComponent } from './index';
 @NgModule({
   /** Root App Component */
   bootstrap: [ AppComponent ],
-  /** Our Components */
-  declarations: [ AppComponent ],
   imports: [
     /**
      * NOTE: Needs to be your first import (!)
      * BrowserModule, HttpModule, and JsonpModule are included
      */
     UniversalModule,
-    FormsModule
+    AppModule
     /**
      * using routes
      */
     // RouterModule.forRoot(appRoutes)
   ]
 })
-export class AppModule {
+export class BrowserAppModule {
 
 }

--- a/packages/universal-cli/blueprints/universal/files/__path__/app/app.node.module.ts
+++ b/packages/universal-cli/blueprints/universal/files/__path__/app/app.node.module.ts
@@ -8,7 +8,7 @@
 
 import { NgModule } from '@angular/core';
 import { UniversalModule } from 'angular2-universal';
-import { FormsModule } from '@angular/forms';
+import { AppModule } from './app.module';
 import { AppComponent } from './index';
 // import { RouterModule } from '@angular/router';
 // import { appRoutes } from './app/app.routing';
@@ -19,21 +19,19 @@ import { AppComponent } from './index';
 @NgModule({
   /** Root App Component */
   bootstrap: [ AppComponent ],
-  /** Our Components */
-  declarations: [ AppComponent ],
   imports: [
     /**
      * NOTE: Needs to be your first import (!)
      * NodeModule, NodeHttpModule, NodeJsonpModule are included
      */
     UniversalModule,
-    FormsModule
+    AppModule
     /**
      * using routes
      */
     // RouterModule.forRoot(appRoutes)
   ]
 })
-export class AppModule {
+export class NodeAppModule {
 
 }

--- a/packages/universal-cli/blueprints/universal/files/__path__/client.ts
+++ b/packages/universal-cli/blueprints/universal/files/__path__/client.ts
@@ -5,8 +5,8 @@ import './polyfills.ts';
 import './__2.1.1.workaround.ts'; // temporary until 2.1.1 things are patched in Core
 import { enableProdMode } from '@angular/core';
 import { environment } from './environments/environment';
-import { platformUniversalDynamic } from 'angular2-universal';
-import { AppModule } from './app/app.browser.module';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { BrowserAppModule } from './app/app.browser.module';
 
 /**
  * enable prod mode for production environments
@@ -15,6 +15,4 @@ if (environment.production) {
   enableProdMode();
 }
 
-const platformRef = platformUniversalDynamic();
-
-platformRef.bootstrapModule(AppModule);
+platformBrowserDynamic().bootstrapModule(BrowserAppModule);

--- a/packages/universal-cli/blueprints/universal/files/__path__/server.ts
+++ b/packages/universal-cli/blueprints/universal/files/__path__/server.ts
@@ -8,7 +8,7 @@ import * as express from 'express';
 import * as compression from 'compression';
 import { createEngine } from 'angular2-express-engine';
 import { enableProdMode } from '@angular/core';
-import { AppModule } from './app/app.node.module';
+import { NodeAppModule } from './app/app.node.module';
 import { environment } from './environments/environment';
 import { routes } from './server.routes';
 
@@ -56,7 +56,7 @@ function ngApp(req: any, res: any) {
   res.render('index', {
     req,
     res,
-    ngModule: AppModule,
+    ngModule: NodeAppModule,
     preboot: false,
     baseUrl: '/',
     requestUrl: req.originalUrl,

--- a/packages/universal-cli/models/webpack-config.ts
+++ b/packages/universal-cli/models/webpack-config.ts
@@ -40,7 +40,7 @@ export class NgCliWebpackConfig {
     appConfig.outDir = outputDir || appConfig.outDir;
 
     if (appConfig.universal === true && isAoT === true) {
-      throw new Error('AoT is not supported in universal yet.');
+      console.warn('For now, AoT is only supported on client side.');
     }
 
     let baseConfig = getWebpackCommonConfig(
@@ -84,7 +84,7 @@ export class NgCliWebpackConfig {
       ));
 
       this.configs.push(webpackMerge(
-        typescriptConfigPartial,
+        getWebpackNonAotConfigPartial(this.ngCliProject.root, appConfig),
         getWebpackNodeConfig(
           this.ngCliProject.root,
           environment,

--- a/tests/acceptance/init.spec.js
+++ b/tests/acceptance/init.spec.js
@@ -66,7 +66,6 @@ describe('Acceptance: ung init', function () {
     }
     if (additionalFolders.indexOf('universal') > -1) {
       expected = expected.filter(p => p.indexOf('main.ts') < 0);
-      expected = expected.filter(p => p.indexOf('app.module.ts') < 0);
     }
 
     if (!routing) {

--- a/tests/e2e/tests/build/aot-i18n.ts
+++ b/tests/e2e/tests/build/aot-i18n.ts
@@ -22,10 +22,10 @@ export default function() {
       '<h1 i18n="An introduction header for this sample">Hello i18n!</h1>'))
     .then(() => ng('build', '--aot', '--i18n-file', 'src/locale/messages.fr.xlf', '--i18n-format',
       'xlf', '--locale', 'fr'))
-    .then(() => expectFileToMatch(`${getClientDist()}/client.bundle.js`, /Bonjour i18n!/))
+    .then(() => expectFileToMatch(`${getClientDist()}client.bundle.js`, /Bonjour i18n!/))
     .then(() => ng('build', '--aot'))
     .then(() => expectToFail(() => {
-      return expectFileToMatch(`${getClientDist()}/client.bundle.js`, /Bonjour i18n!/);
+      return expectFileToMatch(`${getClientDist()}client.bundle.js`, /Bonjour i18n!/);
     }))
-    .then(() => expectFileToMatch(`${getClientDist()}/client.bundle.js`, /Hello i18n!/));
+    .then(() => expectFileToMatch(`${getClientDist()}client.bundle.js`, /Hello i18n!/));
 }

--- a/tests/e2e/tests/build/aot-i18n.ts
+++ b/tests/e2e/tests/build/aot-i18n.ts
@@ -1,34 +1,31 @@
 import {ng} from '../../utils/process';
 import {expectFileToMatch, writeFile, createDir, appendToFile} from '../../utils/fs';
-import {expectToFail, isUniversalTest} from '../../utils/utils';
+import {expectToFail, getClientDist} from '../../utils/utils';
 
 export default function() {
-    if (isUniversalTest()) {
-      return Promise.resolve()
-        .then(() => expectToFail(() => ng('build', '--aot')));
-    } else {
-    return Promise.resolve()
-      .then(() => createDir('src/locale'))
-      .then(() => writeFile('src/locale/messages.fr.xlf', `
-        <?xml version="1.0" encoding="UTF-8" ?>
-          <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-          <file source-language="en" datatype="plaintext" original="ng2.template">
-            <body>
-              <trans-unit id="8def8481e91291a52f9baa31cbdb313e6a6ca02b" datatype="html">
-                <source>Hello i18n!</source>
-                <target>Bonjour i18n!</target>
-                <note priority="1" from="description">An introduction header for this sample</note>
-              </trans-unit>
-            </body>
-          </file>
-          </xliff>`))
-      .then(() => appendToFile('src/app/app.component.html',
-        '<h1 i18n="An introduction header for this sample">Hello i18n!</h1>'))
-      .then(() => ng('build', '--aot', '--i18n-file', 'src/locale/messages.fr.xlf', '--i18n-format',
-        'xlf', '--locale', 'fr'))
-      .then(() => expectFileToMatch('dist/main.bundle.js', /Bonjour i18n!/))
-      .then(() => ng('build', '--aot'))
-      .then(() => expectToFail(() => expectFileToMatch('dist/main.bundle.js', /Bonjour i18n!/)))
-      .then(() => expectFileToMatch('dist/main.bundle.js', /Hello i18n!/));
-  }
+  return Promise.resolve()
+    .then(() => createDir('src/locale'))
+    .then(() => writeFile('src/locale/messages.fr.xlf', `
+      <?xml version="1.0" encoding="UTF-8" ?>
+        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+        <file source-language="en" datatype="plaintext" original="ng2.template">
+          <body>
+            <trans-unit id="8def8481e91291a52f9baa31cbdb313e6a6ca02b" datatype="html">
+              <source>Hello i18n!</source>
+              <target>Bonjour i18n!</target>
+              <note priority="1" from="description">An introduction header for this sample</note>
+            </trans-unit>
+          </body>
+        </file>
+        </xliff>`))
+    .then(() => appendToFile('src/app/app.component.html',
+      '<h1 i18n="An introduction header for this sample">Hello i18n!</h1>'))
+    .then(() => ng('build', '--aot', '--i18n-file', 'src/locale/messages.fr.xlf', '--i18n-format',
+      'xlf', '--locale', 'fr'))
+    .then(() => expectFileToMatch(`${getClientDist()}/client.bundle.js`, /Bonjour i18n!/))
+    .then(() => ng('build', '--aot'))
+    .then(() => expectToFail(() => {
+      return expectFileToMatch(`${getClientDist()}/client.bundle.js`, /Bonjour i18n!/)
+    }))
+    .then(() => expectFileToMatch(`${getClientDist()}/client.bundle.js`, /Hello i18n!/));
 }

--- a/tests/e2e/tests/build/aot-i18n.ts
+++ b/tests/e2e/tests/build/aot-i18n.ts
@@ -25,7 +25,7 @@ export default function() {
     .then(() => expectFileToMatch(`${getClientDist()}/client.bundle.js`, /Bonjour i18n!/))
     .then(() => ng('build', '--aot'))
     .then(() => expectToFail(() => {
-      return expectFileToMatch(`${getClientDist()}/client.bundle.js`, /Bonjour i18n!/)
+      return expectFileToMatch(`${getClientDist()}/client.bundle.js`, /Bonjour i18n!/);
     }))
     .then(() => expectFileToMatch(`${getClientDist()}/client.bundle.js`, /Hello i18n!/));
 }

--- a/tests/e2e/tests/build/aot-i18n.ts
+++ b/tests/e2e/tests/build/aot-i18n.ts
@@ -1,6 +1,6 @@
 import {ng} from '../../utils/process';
 import {expectFileToMatch, writeFile, createDir, appendToFile} from '../../utils/fs';
-import {expectToFail, getClientDist} from '../../utils/utils';
+import {expectToFail, getAppMain, getClientDist} from '../../utils/utils';
 
 export default function() {
   return Promise.resolve()
@@ -22,10 +22,10 @@ export default function() {
       '<h1 i18n="An introduction header for this sample">Hello i18n!</h1>'))
     .then(() => ng('build', '--aot', '--i18n-file', 'src/locale/messages.fr.xlf', '--i18n-format',
       'xlf', '--locale', 'fr'))
-    .then(() => expectFileToMatch(`${getClientDist()}client.bundle.js`, /Bonjour i18n!/))
+    .then(() => expectFileToMatch(`${getClientDist()}${getAppMain()}.bundle.js`, /Bonjour i18n!/))
     .then(() => ng('build', '--aot'))
     .then(() => expectToFail(() => {
-      return expectFileToMatch(`${getClientDist()}client.bundle.js`, /Bonjour i18n!/);
+      return expectFileToMatch(`${getClientDist()}${getAppMain()}.bundle.js`, /Bonjour i18n!/);
     }))
-    .then(() => expectFileToMatch(`${getClientDist()}client.bundle.js`, /Hello i18n!/));
+    .then(() => expectFileToMatch(`${getClientDist()}${getAppMain()}.bundle.js`, /Hello i18n!/));
 }

--- a/tests/e2e/tests/build/aot.ts
+++ b/tests/e2e/tests/build/aot.ts
@@ -1,9 +1,9 @@
 import { ng } from '../../utils/process';
 import { expectFileToMatch } from '../../utils/fs';
-import { getClientDist, getAppMain, getMainAppModule } from '../../utils/utils';
+import { getClientDist, getAppMain, getMainAppModuleRegex } from '../../utils/utils';
 
 export default function () {
   return ng('build', '--aot')
     .then(() => expectFileToMatch(`${getClientDist()}${getAppMain()}.bundle.js`,
-      new RegExp(`bootstrapModuleFactory.*\/\* ${getMainAppModule()}NgFactory \*\/`)));
+      getMainAppModuleRegex()));
 }

--- a/tests/e2e/tests/build/aot.ts
+++ b/tests/e2e/tests/build/aot.ts
@@ -1,14 +1,9 @@
 import { ng } from '../../utils/process';
 import { expectFileToMatch } from '../../utils/fs';
-import { isUniversalTest, expectToFail, getClientDist } from '../../utils/utils';
+import { getClientDist } from '../../utils/utils';
 
 export default function () {
-  if (isUniversalTest()) {
-    return Promise.resolve()
-      .then(() => expectToFail(() => ng('build', '--aot')));
-  } else {
-    return ng('build', '--aot')
-      .then(() => expectFileToMatch(`${getClientDist()}main.bundle.js`,
-        /bootstrapModuleFactory.*\/\* AppModuleNgFactory \*\//));
-  }
+  return ng('build', '--aot')
+    .then(() => expectFileToMatch(`${getClientDist()}client.bundle.js`,
+      /bootstrapModuleFactory.*\/\* BrowserAppModuleNgFactory \*\//));
 }

--- a/tests/e2e/tests/build/aot.ts
+++ b/tests/e2e/tests/build/aot.ts
@@ -1,9 +1,9 @@
 import { ng } from '../../utils/process';
 import { expectFileToMatch } from '../../utils/fs';
-import { getClientDist, getAppMain } from '../../utils/utils';
+import { getClientDist, getAppMain, getMainAppModule } from '../../utils/utils';
 
 export default function () {
   return ng('build', '--aot')
     .then(() => expectFileToMatch(`${getClientDist()}${getAppMain()}.bundle.js`,
-      /bootstrapModuleFactory.*\/\* BrowserAppModuleNgFactory \*\//));
+      new RegExp(`bootstrapModuleFactory.*\/\* ${getMainAppModule()}NgFactory \*\/`)));
 }

--- a/tests/e2e/tests/build/aot.ts
+++ b/tests/e2e/tests/build/aot.ts
@@ -1,9 +1,9 @@
 import { ng } from '../../utils/process';
 import { expectFileToMatch } from '../../utils/fs';
-import { getClientDist } from '../../utils/utils';
+import { getClientDist, getAppMain } from '../../utils/utils';
 
 export default function () {
   return ng('build', '--aot')
-    .then(() => expectFileToMatch(`${getClientDist()}client.bundle.js`,
+    .then(() => expectFileToMatch(`${getClientDist()}${getAppMain()}.bundle.js`,
       /bootstrapModuleFactory.*\/\* BrowserAppModuleNgFactory \*\//));
 }

--- a/tests/e2e/utils/utils.ts
+++ b/tests/e2e/utils/utils.ts
@@ -22,6 +22,10 @@ export function getClientDist() {
   return isUniversalTest() ? 'dist/client/' : 'dist/';
 }
 
+export function getMainAppModule() {
+  return isUniversalTest() ? 'BrowserAppModule' : 'AppModule';
+}
+
 export function wait(msecs: number) {
   return new Promise((resolve) => {
     setTimeout(resolve, msecs);

--- a/tests/e2e/utils/utils.ts
+++ b/tests/e2e/utils/utils.ts
@@ -22,8 +22,10 @@ export function getClientDist() {
   return isUniversalTest() ? 'dist/client/' : 'dist/';
 }
 
-export function getMainAppModule() {
-  return isUniversalTest() ? 'BrowserAppModule' : 'AppModule';
+export function getMainAppModuleRegex() {
+  return isUniversalTest() ?
+    /bootstrapModuleFactory.*\/\* BrowserAppModuleNgFactory \*\// :
+    /bootstrapModuleFactory.*\/\* AppModuleNgFactory \*\//;
 }
 
 export function wait(msecs: number) {


### PR DESCRIPTION
This supports AoT on client side.

I temporarily set the typescript webpack config to always be not aot and changed the error to a warning.

I altered the way modules were imported so that they both share a common AppModule.

To test:
```
ung new uniaotclient --universal
cd uniaotclient
npm link universal-cli
ung serve --aot
ung build --aot
ung serve --aot --prod
ung build --aot --prod
```

Partially Fixes: https://github.com/devCrossNet/universal-cli/issues/13