### PR TITLE
fix(@angular/cli): temporarily compare commit to rebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-<a name="1.0.0-beta.33"></a>
-# [1.0.0-beta.33](https://github.com/angular/angular-cli/compare/v1.0.0-beta.32...v1.0.0-beta.33) (2017-02-25)
+<a name="1.0.0-rc.0"></a>
+# [1.0.0-rc.0](https://github.com/angular/angular-cli/compare/v1.0.0-beta.32...v1.0.0-rc.0) (2017-02-25)
 
 
 ### Bug Fixes

--- a/scripts/test-commit-messages.js
+++ b/scripts/test-commit-messages.js
@@ -32,7 +32,7 @@ logger
 // Note: This is based on the gulp task found in the angular/angular repository
 
 exec(
-  'git fetch origin master && git log --reverse --format=%s origin/master.. --no-merges',
+  'git fetch origin rebase && git log --reverse --format=%s origin/rebase.. --no-merges',
   (error, stdout, stderr) => {
     if (error) {
       logger.fatal(stderr);


### PR DESCRIPTION
Tests were breaking because it was comparing to our master branch.. temporarily set it to compare to rebase branch?