### PR TITLE
fix(@angular/cli): lock codelyzer version

### DIFF
--- a/packages/universal-cli/blueprints/ng2/files/package.json
+++ b/packages/universal-cli/blueprints/ng2/files/package.json
@@ -51,7 +51,7 @@
     "@types/mime": "0.0.28",
     "@types/serve-static": "^1.7.27",<% } %>
     "universal-cli": "<%= version %>",
-    "codelyzer": "~2.0.0-beta.1",
+    "codelyzer": "2.0.0",
     "jasmine-core": "2.5.2",
     "jasmine-spec-reporter": "2.5.0",
     "karma": "1.2.0",


### PR DESCRIPTION
Codelyzer 2.0.1+ looks for a ng version which doesnt exist below @angular/core 2.4.3